### PR TITLE
Fix for two "@" being displayed - if username already contains "@"

### DIFF
--- a/src/pages/Bot.tsx
+++ b/src/pages/Bot.tsx
@@ -36,15 +36,12 @@ export default function Bot() {
     <>
       <Link to="/">back to main</Link>
       <Header>
-        <ExternalLink to={`https://t.me/${
-            username.startsWith("@")
-              ? username.substr(1)
-              : username
-          }`}>{
-            username.startsWith("@")
-              ? username
-              : `@${username}`
-          }
+        <ExternalLink
+          to={`https://t.me/${
+            username.startsWith('@') ? username.substr(1) : username
+          }`}
+        >
+          {username.startsWith('@') ? username : `@${username}`}
         </ExternalLink>
       </Header>
       {!bot && !notFound && <BodyText>🤔 loading...</BodyText>}

--- a/src/pages/Bot.tsx
+++ b/src/pages/Bot.tsx
@@ -36,7 +36,16 @@ export default function Bot() {
     <>
       <Link to="/">back to main</Link>
       <Header>
-        <ExternalLink to={`https://t.me/${username}`}>@{username}</ExternalLink>
+        <ExternalLink to={`https://t.me/${
+            username.startsWith("@")
+              ? username.substr(1)
+              : username
+          }`}>{
+            username.startsWith("@")
+              ? username
+              : `@${username}`
+          }
+        </ExternalLink>
       </Header>
       {!bot && !notFound && <BodyText>🤔 loading...</BodyText>}
       {notFound && (


### PR DESCRIPTION
**Fix for two "@" being displayed if entered username already contains "@" at the beginning**

![image](https://user-images.githubusercontent.com/70066170/140927056-405a8ad8-d2f4-4e1d-8318-da4df7614280.png)
_See the URL also_

The website's find bot text input currently supports "@" in the beginning and also the placeholding hint is "@username". And if the user enters a "@" in the input -> the results are showing right, but the head and URL to the bot are incorrect because they have an extra "@" in the username.

This PR,
- Checks whether there is already "@" in the beginning, if there is, remove it in the t.me URL.
- Checks whether there is already "@" in the beginning, and if not, adds one before the name.
- This is expected to remove both issues.

**Note**: I couldn't run checks locally since there was an issue when trying to run `yarn start`. So, I am not sure if this can fix the issue though.